### PR TITLE
refactor: split generated output into individual files per enum/resource

### DIFF
--- a/src/generators/enums.ts
+++ b/src/generators/enums.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { getPhpFiles, readFileSafe, writeFileEnsureDir } from '../utils/file.js';
+import { getPhpFiles, readFileSafe, writeFileEnsureDir, cleanOutputDir } from '../utils/file.js';
 import { parseEnumContent, type EnumDefinition } from '../utils/php-parser.js';
 import {
   printNodes,
@@ -24,7 +24,34 @@ export type EnumGeneratorOptions = {
 };
 
 /**
+ * Generate TypeScript type declaration for a single enum.
+ */
+export function generateSingleEnumTypeScript(enumDef: EnumDefinition): string {
+  const hasLabels = enumDef.cases.some((c) => c.label);
+
+  let node: ts.Node;
+  if (hasLabels) {
+    const properties = enumDef.cases.map((c) => ({
+      name: c.key,
+      type: createTypeLiteral([
+        { name: 'value', type: ts.factory.createLiteralTypeNode(createStringLiteral(String(c.value))) },
+        {
+          name: 'label',
+          type: ts.factory.createLiteralTypeNode(createStringLiteral(c.label || String(c.value))),
+        },
+      ]),
+    }));
+    node = createDeclareConstWithType(enumDef.name, createTypeLiteral(properties));
+  } else {
+    node = createEnum(enumDef.name, enumDef.cases.map((c) => ({ key: c.key, value: c.value })));
+  }
+
+  return printNode(node) + '\n';
+}
+
+/**
  * Generate TypeScript type declarations for enums.
+ * @deprecated Use generateSingleEnumTypeScript for individual files
  */
 export function generateEnumTypeScript(enums: Record<string, EnumDefinition>): string {
   const nodes: ts.Node[] = [];
@@ -57,7 +84,35 @@ export function generateEnumTypeScript(enums: Record<string, EnumDefinition>): s
 }
 
 /**
+ * Generate runtime JavaScript for a single enum.
+ */
+export function generateSingleEnumRuntime(enumDef: EnumDefinition, prettyPrint = true): string {
+  const hasLabels = enumDef.cases.some((c) => c.label);
+
+  const properties = enumDef.cases.map((c) => {
+    let value: ts.Expression;
+    if (hasLabels) {
+      value = createObjectLiteral(
+        [
+          { key: 'value', value: createStringLiteral(String(c.value)) },
+          { key: 'label', value: createStringLiteral(c.label || String(c.value)) },
+        ],
+        prettyPrint
+      );
+    } else if (typeof c.value === 'number') {
+      value = createNumericLiteral(c.value);
+    } else {
+      value = createStringLiteral(String(c.value));
+    }
+    return { key: c.key, value };
+  });
+
+  return printNode(createConstObject(enumDef.name, properties)) + '\n';
+}
+
+/**
  * Generate runtime JavaScript for enums.
+ * @deprecated Use generateSingleEnumRuntime for individual files
  */
 export function generateEnumRuntime(enums: Record<string, EnumDefinition>, prettyPrint = true): string {
   const nodes: ts.Node[] = [];
@@ -131,18 +186,33 @@ export function collectEnums(enumsDir: string): Record<string, EnumDefinition> {
 export function generateEnums(options: EnumGeneratorOptions): void {
   const { enumsDir, outputDir, packageName, prettyPrint = true } = options;
 
+  // Clean existing generated files
+  cleanOutputDir(outputDir);
+
   // Collect all enums
   const enums = collectEnums(enumsDir);
+  const enumNames = Object.keys(enums);
 
-  // Generate TypeScript declarations
-  const dtsContent = generateEnumTypeScript(enums);
-  const dtsPath = join(outputDir, 'index.d.ts');
-  writeFileEnsureDir(dtsPath, dtsContent);
+  // Generate individual files for each enum
+  for (const enumName of enumNames) {
+    const enumDef = enums[enumName];
 
-  // Generate runtime JavaScript
-  const jsContent = generateEnumRuntime(enums, prettyPrint);
-  const jsPath = join(outputDir, 'index.js');
-  writeFileEnsureDir(jsPath, jsContent);
+    // Generate {EnumName}.d.ts
+    const dtsContent = generateSingleEnumTypeScript(enumDef);
+    writeFileEnsureDir(join(outputDir, `${enumName}.d.ts`), dtsContent);
+
+    // Generate {EnumName}.js
+    const jsContent = generateSingleEnumRuntime(enumDef, prettyPrint);
+    writeFileEnsureDir(join(outputDir, `${enumName}.js`), jsContent);
+  }
+
+  // Generate barrel index.d.ts
+  const indexDts = enumNames.map((n) => `export { ${n} } from './${n}.js';`).join('\n') + '\n';
+  writeFileEnsureDir(join(outputDir, 'index.d.ts'), indexDts);
+
+  // Generate barrel index.js
+  const indexJs = enumNames.map((n) => `export { ${n} } from './${n}.js';`).join('\n') + '\n';
+  writeFileEnsureDir(join(outputDir, 'index.js'), indexJs);
 
   // Generate package.json
   const pkgJson = JSON.stringify(

--- a/src/generators/resources.ts
+++ b/src/generators/resources.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import { existsSync } from 'node:fs';
 import { join, parse } from 'node:path';
-import { getPhpFiles, readFileSafe, writeFileEnsureDir } from '../utils/file.js';
+import { getPhpFiles, readFileSafe, writeFileEnsureDir, cleanOutputDir } from '../utils/file.js';
 import {
   extractDocblockArrayShape,
   parseResourceFieldsAst,
@@ -30,7 +30,59 @@ export type ResourceGeneratorOptions = {
 export type FieldInfo = ResourceFieldInfo;
 
 /**
+ * Generate TypeScript type declaration for a single resource.
+ */
+export function generateSingleResourceTypeScript(
+  className: string,
+  fields: Record<string, ResourceFieldInfo>,
+  isFallback: boolean,
+  referencedEnums: Set<string>
+): string {
+  const nodes: ts.Node[] = [];
+
+  // Find which enums this resource actually uses
+  const usedEnums = new Set<string>();
+  for (const info of Object.values(fields)) {
+    const type = info.type || '';
+    for (const enumName of referencedEnums) {
+      if (type.includes(enumName)) {
+        usedEnums.add(enumName);
+      }
+    }
+  }
+
+  // Import referenced enums from @app/enums
+  if (usedEnums.size > 0) {
+    const enumImports = Array.from(usedEnums).sort();
+    nodes.push(createImportType(enumImports, '@app/enums'));
+  }
+
+  if (isFallback) {
+    // Fallback type: Record<string, any>
+    const recordType = ts.factory.createTypeReferenceNode(ts.factory.createIdentifier('Record'), [
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+    ]);
+    nodes.push(createTypeAlias(className, recordType));
+  } else {
+    // Create type literal with all fields
+    const properties = Object.keys(fields).map((key) => {
+      const info = fields[key];
+      return {
+        name: key,
+        type: parseTypeString(info.type || 'any'),
+        optional: info.optional,
+      };
+    });
+    nodes.push(createTypeAlias(className, createTypeLiteral(properties)));
+  }
+
+  return nodes.map(printNode).join('\n\n') + '\n';
+}
+
+/**
  * Generate TypeScript type declarations for resources.
+ * @deprecated Use generateSingleResourceTypeScript for individual files
  */
 export function generateResourceTypeScript(
   resources: Record<string, Record<string, ResourceFieldInfo>>,
@@ -91,6 +143,9 @@ export function generateResourceRuntime(): string {
 export function generateResources(options: ResourceGeneratorOptions): void {
   const { resourcesDir, enumsDir, modelsDir, outputDir, packageName } = options;
 
+  // Clean existing generated files
+  cleanOutputDir(outputDir);
+
   const collectedEnums: Record<string, EnumDefinition> = {};
   const resources: Record<string, Record<string, ResourceFieldInfo>> = {};
   const fallbacks: string[] = [];
@@ -132,16 +187,28 @@ export function generateResources(options: ResourceGeneratorOptions): void {
 
   // Track which enums are actually referenced
   const referencedEnums = new Set(Object.keys(collectedEnums));
+  const resourceNames = Object.keys(resources);
 
-  // Generate TypeScript declarations
-  const dtsContent = generateResourceTypeScript(resources, fallbacks, referencedEnums);
-  const dtsPath = join(outputDir, 'index.d.ts');
-  writeFileEnsureDir(dtsPath, dtsContent);
+  // Generate individual files for each resource
+  for (const className of resourceNames) {
+    const fields = resources[className];
+    const isFallback = fallbacks.includes(className);
 
-  // Generate runtime JavaScript
-  const jsContent = generateResourceRuntime();
-  const jsPath = join(outputDir, 'index.js');
-  writeFileEnsureDir(jsPath, jsContent);
+    // Generate {ResourceName}.d.ts
+    const dtsContent = generateSingleResourceTypeScript(className, fields, isFallback, referencedEnums);
+    writeFileEnsureDir(join(outputDir, `${className}.d.ts`), dtsContent);
+
+    // Generate {ResourceName}.js (empty export for type-only)
+    writeFileEnsureDir(join(outputDir, `${className}.js`), 'export {};\n');
+  }
+
+  // Generate barrel index.d.ts
+  const indexDts = resourceNames.map((n) => `export type { ${n} } from './${n}.js';`).join('\n') + '\n';
+  writeFileEnsureDir(join(outputDir, 'index.d.ts'), indexDts);
+
+  // Generate barrel index.js
+  const indexJs = resourceNames.map((n) => `export * from './${n}.js';`).join('\n') + '\n';
+  writeFileEnsureDir(join(outputDir, 'index.js'), indexJs);
 
   // Generate package.json
   const pkgJson = JSON.stringify(

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, unlinkSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 /**
  * Safely read a file, returning null if it doesn't exist or can't be read.
@@ -29,4 +29,18 @@ export function getPhpFiles(dir: string): string[] {
     return [];
   }
   return readdirSync(dir).filter((f) => f.endsWith('.php'));
+}
+
+/**
+ * Clean generated files from output directory, keeping package.json.
+ */
+export function cleanOutputDir(outputDir: string): void {
+  if (!existsSync(outputDir)) return;
+
+  const files = readdirSync(outputDir);
+  for (const file of files) {
+    if (file.endsWith('.d.ts') || file.endsWith('.js')) {
+      unlinkSync(join(outputDir, file));
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Split bundled `index.d.ts` / `index.js` output into individual files per enum and resource (e.g., `StatusEnum.d.ts`, `UserResource.d.ts`)
- Added barrel export files (`index.d.ts`, `index.js`) that re-export all types for backwards-compatible imports
- Added `cleanOutputDir()` helper to remove stale generated files when enums/resources are deleted
- Individual resource files now only import the specific enums they reference

## New Output Structure

```
node_modules/@ferry/enums/
├── StatusEnum.d.ts
├── StatusEnum.js
├── index.d.ts       # export { StatusEnum } from './StatusEnum.js';
└── index.js

node_modules/@ferry/resources/
├── UserResource.d.ts
├── UserResource.js
├── index.d.ts       # export type { UserResource } from './UserResource.js';
└── index.js
```

## Test Plan

- [x] All existing tests pass
- [x] Build succeeds with no TypeScript errors
