### PR TITLE
feature: add source map support for Go to Definition navigation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export default function ferry(options: ResourceTypesPluginOptions = {}): Plugin 
       outputDir: enumsOutputDir,
       packageName: `${namespace}/enums`,
       prettyPrint,
+      cwd,
     });
 
     // Generate @app/resources package
@@ -55,6 +56,7 @@ export default function ferry(options: ResourceTypesPluginOptions = {}): Plugin 
       outputDir: resourcesOutputDir,
       packageName: `${namespace}/resources`,
       prettyPrint,
+      cwd,
     });
   }
 
@@ -93,6 +95,7 @@ export default function ferry(options: ResourceTypesPluginOptions = {}): Plugin 
         enumsDir,
         outputDir: enumsOutputDir,
         packageName: `${namespace}/enums`,
+        cwd,
         server,
       });
 
@@ -103,6 +106,7 @@ export default function ferry(options: ResourceTypesPluginOptions = {}): Plugin 
         modelsDir,
         outputDir: resourcesOutputDir,
         packageName: `${namespace}/resources`,
+        cwd,
         server,
       });
     },

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -39,7 +39,7 @@ export function cleanOutputDir(outputDir: string): void {
 
   const files = readdirSync(outputDir);
   for (const file of files) {
-    if (file.endsWith('.d.ts') || file.endsWith('.js')) {
+    if (file.endsWith('.d.ts') || file.endsWith('.js') || file.endsWith('.d.ts.map')) {
       unlinkSync(join(outputDir, file));
     }
   }

--- a/src/utils/source-map.ts
+++ b/src/utils/source-map.ts
@@ -1,0 +1,155 @@
+/**
+ * Source map generation utilities.
+ * Implements the Source Map v3 format with VLQ encoding.
+ */
+
+export type SourceMapping = {
+  generatedLine: number;
+  generatedColumn: number;
+  sourceLine: number;
+  sourceColumn: number;
+  name?: string;
+};
+
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/**
+ * Encode a single number as VLQ (Variable Length Quantity).
+ */
+function encodeVLQ(value: number): string {
+  let result = '';
+  let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
+
+  do {
+    let digit = vlq & 0x1f;
+    vlq >>>= 5;
+    if (vlq > 0) {
+      digit |= 0x20; // continuation bit
+    }
+    result += BASE64_CHARS[digit];
+  } while (vlq > 0);
+
+  return result;
+}
+
+/**
+ * Encode a source map segment.
+ * Each segment contains: generatedColumn, sourceIndex, sourceLine, sourceColumn, [nameIndex]
+ */
+function encodeSegment(
+  generatedColumn: number,
+  sourceIndex: number,
+  sourceLine: number,
+  sourceColumn: number,
+  prevState: { genCol: number; srcIdx: number; srcLine: number; srcCol: number }
+): string {
+  const result =
+    encodeVLQ(generatedColumn - prevState.genCol) +
+    encodeVLQ(sourceIndex - prevState.srcIdx) +
+    encodeVLQ(sourceLine - prevState.srcLine) +
+    encodeVLQ(sourceColumn - prevState.srcCol);
+
+  prevState.genCol = generatedColumn;
+  prevState.srcIdx = sourceIndex;
+  prevState.srcLine = sourceLine;
+  prevState.srcCol = sourceColumn;
+
+  return result;
+}
+
+/**
+ * Generate VLQ-encoded mappings string from mapping entries.
+ */
+function encodeMappings(mappings: SourceMapping[]): string {
+  if (mappings.length === 0) return '';
+
+  // Sort by generated line, then column
+  const sorted = [...mappings].sort((a, b) => {
+    if (a.generatedLine !== b.generatedLine) return a.generatedLine - b.generatedLine;
+    return a.generatedColumn - b.generatedColumn;
+  });
+
+  const lines: string[][] = [];
+  const state = { genCol: 0, srcIdx: 0, srcLine: 0, srcCol: 0 };
+
+  for (const mapping of sorted) {
+    // Ensure we have enough lines
+    while (lines.length < mapping.generatedLine) {
+      lines.push([]);
+      state.genCol = 0; // Reset column at start of each line
+    }
+
+    const lineIndex = mapping.generatedLine - 1;
+    const segment = encodeSegment(
+      mapping.generatedColumn,
+      0, // sourceIndex - always 0 since we have one source file per map
+      mapping.sourceLine - 1, // 0-indexed in source maps
+      mapping.sourceColumn,
+      state
+    );
+
+    lines[lineIndex].push(segment);
+  }
+
+  return lines.map((segments) => segments.join(',')).join(';');
+}
+
+export type SourceMapOptions = {
+  file: string;
+  sourceRoot?: string;
+  sources: string[];
+  sourcesContent?: (string | null)[];
+  names?: string[];
+  mappings: SourceMapping[];
+};
+
+/**
+ * Generate a source map JSON string.
+ */
+export function generateSourceMap(options: SourceMapOptions): string {
+  const { file, sourceRoot = '', sources, sourcesContent, names = [], mappings } = options;
+
+  const map = {
+    version: 3,
+    file,
+    sourceRoot,
+    sources,
+    ...(sourcesContent ? { sourcesContent } : {}),
+    names,
+    mappings: encodeMappings(mappings),
+  };
+
+  return JSON.stringify(map);
+}
+
+/**
+ * Create the sourceMappingURL comment to append to generated files.
+ */
+export function createSourceMapComment(mapFileName: string): string {
+  return `//# sourceMappingURL=${mapFileName}`;
+}
+
+/**
+ * Calculate relative path from one file to another.
+ * Used to compute the source path relative to the generated .d.ts.map file.
+ */
+export function relativePath(from: string, to: string): string {
+  const fromParts = from.split('/').slice(0, -1); // Remove filename
+  const toParts = to.split('/');
+
+  // Find common prefix
+  let commonLength = 0;
+  while (
+    commonLength < fromParts.length &&
+    commonLength < toParts.length &&
+    fromParts[commonLength] === toParts[commonLength]
+  ) {
+    commonLength++;
+  }
+
+  // Build relative path
+  const ups = fromParts.length - commonLength;
+  const remaining = toParts.slice(commonLength);
+
+  return [...Array(ups).fill('..'), ...remaining].join('/');
+}

--- a/src/watchers/enums.ts
+++ b/src/watchers/enums.ts
@@ -11,7 +11,7 @@ export type EnumWatcherOptions = EnumGeneratorOptions & {
  * Set up a watcher for enum files.
  */
 export function setupEnumWatcher(options: EnumWatcherOptions): void {
-  const { enumsDir, outputDir, packageName, server } = options;
+  const { enumsDir, outputDir, packageName, cwd, server } = options;
 
   const enumPattern = join(enumsDir, '*.php');
   const generatedJsPath = join(outputDir, 'index.js');
@@ -28,7 +28,7 @@ export function setupEnumWatcher(options: EnumWatcherOptions): void {
         logFileChange('enums', basename(filePath));
 
         // Regenerate enum files
-        generateEnums({ enumsDir, outputDir, packageName });
+        generateEnums({ enumsDir, outputDir, packageName, cwd });
 
         // Tell Vite the generated file changed (triggers normal HMR)
         server.watcher.emit('change', generatedJsPath);

--- a/src/watchers/resources.ts
+++ b/src/watchers/resources.ts
@@ -11,7 +11,7 @@ export type ResourceWatcherOptions = ResourceGeneratorOptions & {
  * Set up a watcher for resource and model files.
  */
 export function setupResourceWatcher(options: ResourceWatcherOptions): void {
-  const { resourcesDir, enumsDir, modelsDir, outputDir, packageName, server } = options;
+  const { resourcesDir, enumsDir, modelsDir, outputDir, packageName, cwd, server } = options;
 
   const resourcePattern = join(resourcesDir, '*.php');
   const modelPattern = join(modelsDir, '*.php');
@@ -33,7 +33,7 @@ export function setupResourceWatcher(options: ResourceWatcherOptions): void {
         logFileChange(fileType, basename(filePath));
 
         // Regenerate resource types
-        generateResources({ resourcesDir, enumsDir, modelsDir, outputDir, packageName });
+        generateResources({ resourcesDir, enumsDir, modelsDir, outputDir, packageName, cwd });
 
         // Tell Vite the generated type file changed
         // TypeScript will pick up changes automatically

--- a/tests/source-map.spec.ts
+++ b/tests/source-map.spec.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateSourceMap,
+  createSourceMapComment,
+  relativePath,
+  type SourceMapping,
+} from '../src/utils/source-map.js';
+
+describe('createSourceMapComment', () => {
+  it('creates correct sourceMappingURL comment', () => {
+    expect(createSourceMapComment('index.d.ts.map')).toBe('//# sourceMappingURL=index.d.ts.map');
+  });
+
+  it('handles nested paths', () => {
+    expect(createSourceMapComment('types/User.d.ts.map')).toBe('//# sourceMappingURL=types/User.d.ts.map');
+  });
+});
+
+describe('relativePath', () => {
+  it('calculates relative path between files', () => {
+    expect(relativePath('node_modules/@ferry/resources/User.d.ts', 'app/Http/Resources/User.php'))
+      .toBe('../../../app/Http/Resources/User.php');
+  });
+
+  it('handles same directory', () => {
+    expect(relativePath('src/a.ts', 'src/b.ts')).toBe('b.ts');
+  });
+
+  it('handles parent directory', () => {
+    expect(relativePath('src/sub/a.ts', 'src/b.ts')).toBe('../b.ts');
+  });
+});
+
+describe('generateSourceMap', () => {
+  it('generates valid source map JSON', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 0, sourceLine: 5, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'User.d.ts',
+      sources: ['../../../app/Http/Resources/User.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+
+    expect(parsed.version).toBe(3);
+    expect(parsed.file).toBe('User.d.ts');
+    expect(parsed.sources).toEqual(['../../../app/Http/Resources/User.php']);
+    expect(parsed.names).toEqual([]);
+    expect(typeof parsed.mappings).toBe('string');
+  });
+
+  it('generates empty mappings string for no mappings', () => {
+    const result = generateSourceMap({
+      file: 'Empty.d.ts',
+      sources: ['Empty.php'],
+      mappings: [],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mappings).toBe('');
+  });
+
+  it('includes sourceRoot when provided', () => {
+    const result = generateSourceMap({
+      file: 'User.d.ts',
+      sourceRoot: '/project/',
+      sources: ['app/User.php'],
+      mappings: [],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.sourceRoot).toBe('/project/');
+  });
+
+  it('includes sourcesContent when provided', () => {
+    const result = generateSourceMap({
+      file: 'User.d.ts',
+      sources: ['User.php'],
+      sourcesContent: ['<?php class User {}'],
+      mappings: [],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.sourcesContent).toEqual(['<?php class User {}']);
+  });
+
+  it('generates VLQ-encoded mappings for single mapping', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 0, sourceLine: 1, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // First mapping at line 1, col 0, source 0, line 0, col 0 = AAAA
+    expect(parsed.mappings).toBe('AAAA');
+  });
+
+  it('generates correct mappings for multiple lines', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 0, sourceLine: 1, sourceColumn: 0 },
+      { generatedLine: 2, generatedColumn: 0, sourceLine: 2, sourceColumn: 0 },
+      { generatedLine: 3, generatedColumn: 0, sourceLine: 3, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // Each line separated by semicolons
+    expect(parsed.mappings.split(';').length).toBe(3);
+  });
+
+  it('handles multiple mappings on same line', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 0, sourceLine: 1, sourceColumn: 0 },
+      { generatedLine: 1, generatedColumn: 10, sourceLine: 1, sourceColumn: 5 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // Two segments on same line separated by comma
+    expect(parsed.mappings.includes(',')).toBe(true);
+  });
+
+  it('handles non-sequential line numbers', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 2, generatedColumn: 0, sourceLine: 10, sourceColumn: 0 },
+      { generatedLine: 5, generatedColumn: 4, sourceLine: 15, sourceColumn: 2 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // Should have empty lines represented by just semicolons
+    const lines = parsed.mappings.split(';');
+    expect(lines.length).toBe(5);
+    expect(lines[0]).toBe(''); // line 1 empty
+    expect(lines[1]).not.toBe(''); // line 2 has mapping
+    expect(lines[2]).toBe(''); // line 3 empty
+    expect(lines[3]).toBe(''); // line 4 empty
+    expect(lines[4]).not.toBe(''); // line 5 has mapping
+  });
+
+  it('sorts mappings by line and column', () => {
+    // Provide mappings out of order
+    const mappings: SourceMapping[] = [
+      { generatedLine: 2, generatedColumn: 0, sourceLine: 2, sourceColumn: 0 },
+      { generatedLine: 1, generatedColumn: 0, sourceLine: 1, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // Should still produce valid output with line 1 first
+    const lines = parsed.mappings.split(';');
+    expect(lines.length).toBe(2);
+    expect(lines[0]).not.toBe('');
+    expect(lines[1]).not.toBe('');
+  });
+});
+
+describe('VLQ encoding', () => {
+  it('encodes zero correctly', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 0, sourceLine: 1, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mappings).toBe('AAAA');
+  });
+
+  it('encodes small positive numbers correctly', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 1, sourceLine: 1, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // Column 1 encodes as 'C' (1 << 1 = 2, base64[2] = 'C')
+    expect(parsed.mappings).toBe('CAAA');
+  });
+
+  it('encodes larger numbers with continuation bits', () => {
+    const mappings: SourceMapping[] = [
+      { generatedLine: 1, generatedColumn: 100, sourceLine: 1, sourceColumn: 0 },
+    ];
+
+    const result = generateSourceMap({
+      file: 'test.d.ts',
+      sources: ['test.php'],
+      mappings,
+    });
+
+    const parsed = JSON.parse(result);
+    // 100 requires continuation bit
+    expect(parsed.mappings.length).toBeGreaterThan(4);
+  });
+});


### PR DESCRIPTION
## Summary

Add source mapping support to enable "Go to Definition" navigation from generated TypeScript types back to the original PHP source files. (closes #8)

### Features
- Generate `.d.ts.map` source map files for each enum and resource type
- Add JSDoc `@see` comments with PHP file references for hover documentation
- Track source locations (file, line, column) during PHP AST parsing
- Support field-level precision for navigating to specific properties

### Changes
- **Source Map Utility**: New VLQ encoder and source map generator (`src/utils/source-map.ts`)
- **PHP Parser**: Enable AST position tracking and capture source locations for enums, enum cases, and resource fields
- **Enum Generator**: Generate individual `.d.ts`, `.d.ts.map`, and `.js` files with JSDoc comments
- **Resource Generator**: Generate individual `.d.ts`, `.d.ts.map`, and `.js` files with JSDoc comments
- **File Utility**: Clean up `.d.ts.map` files during regeneration
- **Deprecated Functions Removed**: Removed `generateEnumTypeScript`, `generateEnumRuntime`, and `generateResourceTypeScript` in favor of single-file generation functions

### Generated Output Example

```typescript
// UserResource.d.ts
/** @see app/Http/Resources/UserResource.php */
export type UserResource = {
    id: string;
    name: string;
    email: string;
};
//# sourceMappingURL=UserResource.d.ts.map
```

### Test Plan
- [x] All 115 tests pass
- [x] Source map VLQ encoding tests
- [x] PHP parser source location tracking tests
- [x] Enum and resource generator tests with exact output matching
